### PR TITLE
Fix company link in the profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 My name is Will Dean.
 
 I'm working on [PyMC-Marketing](https://github.com/pymc-labs/pymc-marketing)
-with the [PyMC Labs](https:/www.pymc-labs.io) team. We are building a package
+with the [PyMC Labs](https://www.pymc-labs.io) team. We are building a package
 to help make better decisions with Bayesian statistics.
 
 I've created a few other data science projects:


### PR DESCRIPTION
Hi! Just stumbled across your profile while checking for snacks picker support 😀. I tried both links at the top of the readme, but couldn't access one - the company link seems to have a typo in it. I found the company and updated the link, hopefully you don't mind)